### PR TITLE
Fix Travis Complaints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Cryptography
 
 + [Rumkin ciphers](http://rumkin.com/tools/cipher/) - multiple (ancient) crypto stuff
-+ [quipqiup](http://quipqiup.com/) - solving cryptograms
++ [quipqiup](https://quipqiup.com/) - solving cryptograms
 + [xortool](https://github.com/hellman/xortool) - solving multi-byte xor cipher
 + [rsatool](https://github.com/ius/rsatool) - to calculate rsa params
 + [featherduster](https://github.com/nccgroup/featherduster) -  An automated, modular cryptanalysis tool

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@
 + [Hackbar](https://addons.mozilla.org/en-US/firefox/addon/hackbar/) - indispensible addon for web exploitation in firefox
 + [CookieManager](https://addons.mozilla.org/en-US/firefox/addon/cookies-manager-plus/) - addon for firefox
 + [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) - add on for chrome.
-+ [requests](https://github.com/kennethreitz/requests) - python library used for sending HTTP requests
++ [requests](https://github.com/requests/requests) - python library used for sending HTTP requests
 + [Wfuzz](http://www.edge-security.com/wfuzz.php) - to detect directories and pages on the server using common wordlists.
 + [XSS Payloads](https://github.com/nettitude/xss_payloads)


### PR DESCRIPTION
Travis is complaining because of 2 redirects. One is caused due to the requests library actually having moved, and the other is because quipqiup is now in HTTPS :)

This PR fixes these two complaints and gets us green again :)